### PR TITLE
Updated Telegram URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - [Complete Playlist](https://www.youtube.com/playlist?list=PL9gnSGHSqcnr_DxHsP7AW9ftq0AtAyYqJ)
 - [Syllabus](SYLLABUS.md)
 - [Discord for discussions](https://discord.gg/K9kxUXvfND)
-- [Telegram for announcements](https://t.me/commclassroom)
+- [Telegram for announcements](https://telegram.me/commclassroom)
 
 ### Connect with me
 - [Twitter](https://twitter.com/kunalstwt)


### PR DESCRIPTION
In some cases, **t.me** domain gives an error especially on JIO Network. I also experienced this.
But this will not happen in case of **telegram.me** domain.
So I have updated the telegram group URL to  [https://telegram.me/commclassroom](https://telegram.me/commclassroom)