### PR TITLE
Fixed index out of bound error in rotated binary search with duplicates

### DIFF
--- a/lectures/10-binary search/code/src/com/kunal/RBS.java
+++ b/lectures/10-binary search/code/src/com/kunal/RBS.java
@@ -85,13 +85,13 @@ public class RBS {
                 // skip the duplicates
                 // NOTE: what if these elements at start and end were the pivot??
                 // check if start is pivot
-                if (arr[start] > arr[start + 1]) {
+                if (start < end && arr[start] > arr[start + 1]) {
                     return start;
                 }
                 start++;
 
                 // check whether end is pivot
-                if (arr[end] < arr[end - 1]) {
+                if (end > start && arr[end] < arr[end - 1]) {
                     return end - 1;
                 }
                 end--;


### PR DESCRIPTION
The code gave "index out of bound error" for an array with single int, applied a simple check to see whether the start is smaller than end so that start + 1 and end - 1 operation can be performed.