### PR TITLE
Remove equality check for arr[low] and arr[mid]

### DIFF
--- a/lectures/10-binary search/code/src/com/kunal/RBS.java
+++ b/lectures/10-binary search/code/src/com/kunal/RBS.java
@@ -1,5 +1,5 @@
 package com.kunal;
-// https://leetcode.com/problems/search-in-rotated-sorted-array/submissions/
+// https://leetcode.com/problems/search-in-rotated-sorted-array/
 public class RBS {
     public static void main(String[] args) {
         int[] arr = {1,2,3,4,5,5,6};
@@ -58,7 +58,7 @@ public class RBS {
             if (mid > start && arr[mid] < arr[mid - 1]) {
                 return mid-1;
             }
-            if (arr[mid] <= arr[start]) {
+            if (arr[mid] < arr[start]) {
                 end = mid - 1;
             } else {
                 start = mid + 1;


### PR DESCRIPTION
Original
```
 if (arr[mid] <= arr[start]) {
                end = mid - 1;
            } 
```

 
This condition checks if arr[mid] and arr[low] are equal . 
But elements are distinct according to the question. So, this condition will only be true when array size will be 2 . 
For example [7, 2] , but this case will already be handled by above if statements.
so, there is no need to check equality.