### PR TITLE
Updated Telegram URL to telegram.me domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
   <a href="https://discord.io/commclassroom">
     <img width="30px" src="https://www.vectorlogo.zone/logos/discordapp/discordapp-tile.svg" />
   </a>&ensp;
-    <a href="https://t.me/commclassroom">
+    <a href="https://telegram.me/commclassroom">
     <img width="30px" src="https://www.vectorlogo.zone/logos/telegram/telegram-icon.svg" />
   </a> 
   </a>&ensp;


### PR DESCRIPTION
Updated telegram URL from t.me domain to telegram.me domain because on some networks, t.me domain is blocked but this is not the case with telegram.me domain.