### PR TITLE
Fix #459: Add delete feature for last element of CLL

### DIFF
--- a/lectures/18-linkedlist/code/src/com/kunal/CLL.java
+++ b/lectures/18-linkedlist/code/src/com/kunal/CLL.java
@@ -40,6 +40,12 @@ public class CLL {
             return;
         }
 
+        if (head == tail){
+            head = null;
+            tail = null;
+            return;
+        }
+
         if (node.val == val) {
             head = head.next;
             tail.next = head;


### PR DESCRIPTION
# About
This piece of code makes sure that the deletion of the last element of the CLL is possible. 
For more information on the issue, have a look here: #459 
