### PR TITLE
Update DynamicQueue.java

### DIFF
--- a/lectures/19-stacks-n-queues/code/src/com/kunal/DynamicQueue.java
+++ b/lectures/19-stacks-n-queues/code/src/com/kunal/DynamicQueue.java
@@ -22,7 +22,7 @@ public class DynamicQueue extends CircularQueue{
                 temp[i] = data[(front + i) % data.length];
             }
             front = 0;
-            end = data.length;
+            end = size;
             data = temp;
         }
 


### PR DESCRIPTION
Inside the 'insert' method for the DynamicQueue Class, after making a new array of doubled size, the 'end' should be 'this.size' instead of 'data.length'.