### PR TITLE
Fix ArrayIndexOutOfBoundsException error on BinarySearch>>InfiniteArray

### DIFF
--- a/lectures/10-binary search/code/src/com/kunal/InfiniteArray.java
+++ b/lectures/10-binary search/code/src/com/kunal/InfiniteArray.java
@@ -20,6 +20,14 @@ public class InfiniteArray {
             // end = previous end + sizeofbox*2
             end = end + (end - start + 1) * 2;
             start = temp;
+            while (true) {
+                try {
+                    a = arr[end];
+                    break;
+                } catch (ArrayIndexOutOfBoundsException e) {
+                    end--;
+                }
+            }
         }
         return binarySearch(arr, target, start, end);
 


### PR DESCRIPTION
@kunal-kushwaha As we cannot use length of an array in this problem. To fix [this](https://github.com/kunal-kushwaha/DSA-Bootcamp-Java/issues/645#issue-1226452108) error, we can check if ArrayIndexOutOfBoundException is throwing or not inside where we double the size of box/chunk. If the error is throwing then we reduce size of end by 1 and iterate till no error is thrown. 

I know it will increase the working but I guess it is only a way to fix the error (Ofcourse, if we cannot use length). Let me know if I would have to pull a request to fix the error or not.

Code I used to fix the error (inside ans method) : 
```
while (target > arr[end]) {
    int temp = end + 1; // this is my new start
    // double the box value
    // end = previous end + sizeofbox*2
    end = end + (end - start + 1) * 2;
    while (true) {
        try {
            a = arr[end];
            break;
        } catch (ArrayIndexOutOfBoundsException e) {
            end--;
        }
    }
    start = temp;
}