### PR TITLE
4 Sum to 4Sum for consistent KSum questions name.

### DIFF
--- a/assignments/06-searching.md
+++ b/assignments/06-searching.md
@@ -42,7 +42,7 @@
 - [Frequency of the Most Frequent Element](https://leetcode.com/problems/frequency-of-the-most-frequent-element/)
 - [Find the Duplicate Number](https://leetcode.com/problems/find-the-duplicate-number/)
 - [Capacity To Ship Packages Within D Days](https://leetcode.com/problems/capacity-to-ship-packages-within-d-days/)
-- [4 Sum](https://leetcode.com/problems/4sum/)
+- [4Sum](https://leetcode.com/problems/4sum/)
 
 ## Hard
 - [Median of Two Sorted Arrays](https://leetcode.com/problems/median-of-two-sorted-arrays/)


### PR DESCRIPTION
All the places other than `assignments/06-searching.md` KSum question name is written like 2Sum, 3Sum, 4Sum (`assignments/07-sorting.md`).
only here it is written like "4 Sum", so I have changed it to "4Sum"