### PR TITLE
Replacing 29th (duplicate) pattern

### DIFF
--- a/assignments/09-patterns.md
+++ b/assignments/09-patterns.md
@@ -223,15 +223,18 @@ Print these patterns using loops:
          *
 
 29.      
-       *        *
-       **      **
-       ***    ***
-       ****  ****
-       **********
-       ****  ****
-       ***    ***
-       **      **
-       *        *
+   A B C D E F 
+   A B C D E 
+   A B C D 
+   A B C 
+   A B 
+   A 
+   A 
+   A B 
+   A B C 
+   A B C D 
+   A B C D E 
+   A B C D E F
 
 30.         1
           2 1 2


### PR DESCRIPTION
The 29th pattern was a duplicate of the 19th pattern. Hence, replaced with K shape pattern.