### PR TITLE
changed bubble sort loop condition

### DIFF
--- a/lectures/11-sorting/code/src/com/kunal/Main.java
+++ b/lectures/11-sorting/code/src/com/kunal/Main.java
@@ -50,7 +50,7 @@ public class Main {
     static void bubble(int[] arr) {
         boolean swapped;
         // run the steps n-1 times
-        for (int i = 0; i < arr.length; i++) {
+        for (int i = 0; i < arr.length - 1; i++) {
             swapped = false;
             // for each step, max item will come at the last respective index
             for (int j = 1; j < arr.length - i; j++) {


### PR DESCRIPTION
The previous loop was iterating one more time than it needed to. N - 1 elements implies that iterator `i` should go only upto index of second last element, which is `arr.length - 1`