### PR TITLE
Update RBS.java

### DIFF
--- a/lectures/10-binary search/code/src/com/kunal/RBS.java
+++ b/lectures/10-binary search/code/src/com/kunal/RBS.java
@@ -70,7 +70,7 @@ public class RBS {
     static int findPivotWithDuplicates(int[] arr) {
         int start = 0;
         int end = arr.length - 1;
-        while (start <= end) {
+        while (start < end) {
             int mid = start + (end - start) / 2;
             // 4 cases over here
             if (mid < end && arr[mid] > arr[mid + 1]) {


### PR DESCRIPTION
The loop condition inside the 'findPivotWithDuplicates' function has (start <= end)  which fails the code for the test cases like - 
1. nums = {1} , target = anything.
2. nums = {1,1,3} , target = 0.

To solve this, we have to change the condition to (start<end).