### PR TITLE
Used System.gc() to simplify the process of hitting garbage collection in finalize() method example

### DIFF
--- a/lectures/17-oop/code/src/com/kunal/introduction/WrapperExample.java
+++ b/lectures/17-oop/code/src/com/kunal/introduction/WrapperExample.java
@@ -30,6 +30,7 @@ public class WrapperExample {
 //        for (int i = 0; i < 1000000000; i++) {
 //            obj = new A("Random name");
 //        }
+        System.gc(); // Adding System.gc() will recommend the garbage collector to run even for a comparatively small number of unreferenced objects of class A
 
     }
 


### PR DESCRIPTION
At line 33, when we are checking for how many times the object is getting destroyed by garbage collector using the finalize() method, adding System.gc() will recommend the garbage collector to run even for a comparatively small number of unreferenced objects of class A.