### PR TITLE
Update placeholders_list.txt

### DIFF
--- a/lectures/12-strings/code/src/com/kunal/placeholders_list.txt
+++ b/lectures/12-strings/code/src/com/kunal/placeholders_list.txt
@@ -1,10 +1,9 @@
 There are many format specifiers we can use. Here are some common ones:
 
 %c - Character
-%d - Decimal number (base 10)
+%d - Integer number(base 10)
 %e - Exponential floating-point number
-%f - Floating-point number
-%i - Integer (base 10)
+%f - Decimal number(float and double) (base 10)
 %o - Octal number (base 8)
 %s - String
 %u - Unsigned decimal (integer) number


### PR DESCRIPTION
1. In Java, there isn't a specific format specifier %i for integers like in some other programming languages such as C and its derivatives. In Java's printf() method, the format specifier for integers is %d.

2. %f : Supports both double and float numbers in java.