### PR TITLE
updated HashMapFinal put method

### DIFF
--- a/lectures/20-trees/code/AVL/.project
+++ b/lectures/20-trees/code/AVL/.project
@@ -22,12 +22,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1679078569810</id>
+			<id>1723532503196</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/lectures/20-trees/code/Questions/.project
+++ b/lectures/20-trees/code/Questions/.project
@@ -22,12 +22,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1679078569810</id>
+			<id>1723532503203</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/lectures/25-hashmaps/code/Hashmaps introduction/HashMapFinal.java
+++ b/lectures/25-hashmaps/code/Hashmaps introduction/HashMapFinal.java
@@ -9,7 +9,7 @@ public class HashMapFinal<K, V> {
 
   public HashMapFinal() {
     list = new ArrayList<>();
-    for(int i=0; i < 10; i++) {
+    for (int i = 0; i < 10; i++) {
       list.add(new LinkedList<>());
     }
   }
@@ -20,19 +20,20 @@ public class HashMapFinal<K, V> {
     LinkedList<Entity> entities = list.get(hash);
 
     for (Entity entity : entities) {
-      if(entity.key.equals(key)) {
+      if (entity.key.equals(key)) {
         entity.value = value;
         return;
       }
     }
 
-    if((float)(size) / list.size() > lf) {
-      reHash();
-    }
-    
     entities.add(new Entity(key, value));
 
     size++;
+
+    if ((float) (size) / list.size() > lf) {
+      reHash();
+    }
+
   }
 
   private void reHash() {
@@ -43,12 +44,12 @@ public class HashMapFinal<K, V> {
 
     size = 0;
 
-    for(int i=0; i<old.size() * 2; i++) {
+    for (int i = 0; i < old.size() * 2; i++) {
       list.add(new LinkedList<>());
     }
 
-    for(LinkedList<Entity> entries :old) {
-      for(Entity entry : entries) {
+    for (LinkedList<Entity> entries : old) {
+      for (Entity entry : entries) {
         put(entry.key, entry.value);
       }
     }
@@ -57,8 +58,8 @@ public class HashMapFinal<K, V> {
   public V get(K key) {
     int hash = Math.abs(key.hashCode() % list.size());
     LinkedList<Entity> entities = list.get(hash);
-    for(Entity entity : entities) {
-      if(entity.key.equals(key)) {
+    for (Entity entity : entities) {
+      if (entity.key.equals(key)) {
         return entity.value;
       }
     }
@@ -70,9 +71,9 @@ public class HashMapFinal<K, V> {
     LinkedList<Entity> entities = list.get(hash);
 
     Entity target = null;
-    
-    for(Entity entity : entities) {
-      if(entity.key.equals(key)) {
+
+    for (Entity entity : entities) {
+      if (entity.key.equals(key)) {
         target = entity;
         break;
       }
@@ -87,21 +88,21 @@ public class HashMapFinal<K, V> {
   }
 
   @Override
-    public String toString() {
-      StringBuilder builder = new StringBuilder();
-        builder.append("{");
-      for(LinkedList<Entity> entities : list) {
-        for(Entity entity : entities) {
-          builder.append(entity.key);
-          builder.append(" = ");
-          builder.append(entity.value);
-          builder.append(" , ");
-        }
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("{");
+    for (LinkedList<Entity> entities : list) {
+      for (Entity entity : entities) {
+        builder.append(entity.key);
+        builder.append(" = ");
+        builder.append(entity.value);
+        builder.append(" , ");
       }
-      builder.append("}");
-
-      return builder.toString();
     }
+    builder.append("}");
+
+    return builder.toString();
+  }
 
   private class Entity {
     K key;
@@ -113,7 +114,4 @@ public class HashMapFinal<K, V> {
     }
   }
 
-  
 }
-
-


### PR DESCRIPTION
# Context
If we add new Entity after rehashing, then the new Entity will be added in incorrect index because the hash was calculated based on old list's size.
# Changes
I have shifted the conditional rehash statement after the new Entity will be added. This way the new Entity added will be in the correct index since it will be added before the doubling of the size.