### PR TITLE
Fix for issue #1388 - correcting isSafe method in sudoku solver.

### DIFF
--- a/lectures/14-recursion/code/src/com/kunal/backtracking/SudokuSolver.java
+++ b/lectures/14-recursion/code/src/com/kunal/backtracking/SudokuSolver.java
@@ -80,7 +80,7 @@ public class SudokuSolver {
         // check the row
         for (int i = 0; i < board.length; i++) {
             // check if the number is in the row
-            if (board[row][i] == num) {
+            if (board[i][col] == num) {
                 return false;
             }
         }


### PR DESCRIPTION
**Issue id :** #1388 [Link](https://github.com/kunal-kushwaha/DSA-Bootcamp-Java/issues/1388)

**Description :** In isSafe method while checking of the number is already present in the row or not the code was checking in column instead of row.

**Fix applied :**  Corrected the condition inside loop.

**Code tests :** Tested manually using existing and some additional sudoku boards. Working as expected.