### PR TITLE
Updated find method to return the index

### DIFF
--- a/lectures/18-linkedlist/code/src/com/kunal/LL.java
+++ b/lectures/18-linkedlist/code/src/com/kunal/LL.java
@@ -98,15 +98,17 @@ public class LL {
         return val;
     }
 
-    public Node find(int value) {
+   public int find(int value) {
         Node node = head;
+        int index = 0;
         while (node != null) {
             if (node.value == value) {
-                return node;
+                return index;
             }
             node = node.next;
+            index++;
         }
-        return null;
+        return -1;
     }
 
     public Node get(int index) {


### PR DESCRIPTION
Previously the code was giving us the default string representation of the object in the find method which doesn't gives the clear description of the node so instead of that returning the index at which the node is found will be more understandable and clear according to the method name.