### PR TITLE
Fixed broken link for "Array Partition l" in Sorting Assignment

### DIFF
--- a/assignments/07-sorting.md
+++ b/assignments/07-sorting.md
@@ -17,7 +17,7 @@
 - [Intersection of Two Arrays II](https://leetcode.com/problems/intersection-of-two-arrays-ii/)
 - [Third Maximum Number](https://leetcode.com/problems/third-maximum-number/)
 - [Assign Cookies](https://leetcode.com/problems/assign-cookies/)
-- [Array Partition I](https://leetcode.com/problems/array-partition-i/)
+- [Array Partition](https://leetcode.com/problems/array-partition/)
 - [Maximum Product of Three Numbers](https://leetcode.com/problems/maximum-product-of-three-numbers/)
 - [Sort Array By Parity](https://leetcode.com/problems/sort-array-by-parity/)
 - [Sort Array By Parity II](https://leetcode.com/problems/sort-array-by-parity-ii/)


### PR DESCRIPTION
The link to the "Array Partition l" question was showing a 404 error because LeetCode updated the question title from "Array Partition I" to "Array Partition." This change caused the original link to expire. I resolved the issue by updating the link to the correct URL in the assignment.