### PR TITLE
fix: update bubble sort outer loop to run n-1 times

### DIFF
--- a/lectures/11-sorting/code/src/com/kunal/Main.java
+++ b/lectures/11-sorting/code/src/com/kunal/Main.java
@@ -50,7 +50,7 @@ public class Main {
     static void bubble(int[] arr) {
         boolean swapped;
         // run the steps n-1 times
-        for (int i = 0; i < arr.length; i++) {
+        for (int i = 0; i < arr.length - 1; i++) {
             swapped = false;
             // for each step, max item will come at the last respective index
             for (int j = 1; j < arr.length - i; j++) {


### PR DESCRIPTION
**Description:**

- Updated the outer loop condition in the bubble method from i < arr.length to i < arr.length - 1.
- This ensures the loop runs exactly n-1 times, eliminating the unnecessary final pass.